### PR TITLE
Refactored `<LinkTab>` styling

### DIFF
--- a/src/components/display/graflogo/__snapshots__/GrafLogo.test.js.snap
+++ b/src/components/display/graflogo/__snapshots__/GrafLogo.test.js.snap
@@ -14,6 +14,7 @@ Object {
           Driving Park
         </h1>
         <span
+          class="undefined"
           id="graf"
         >
           THRIVING
@@ -31,6 +32,7 @@ Object {
         Driving Park
       </h1>
       <span
+        class="undefined"
         id="graf"
       >
         THRIVING

--- a/src/components/display/linktab/LinkTab.js
+++ b/src/components/display/linktab/LinkTab.js
@@ -6,8 +6,9 @@
             - border radius
             - drop shadow
         [√] Style if active
-        [] Make tab display responsive
- */
+        [√] Make tab display responsive
+        [] Refactor to not look like a tab
+*/
 //@flow
 import * as React from 'react'
 import useViewport from '../../../hooks/useViewport'

--- a/src/components/display/linktab/LinkTab.scoped.scss
+++ b/src/components/display/linktab/LinkTab.scoped.scss
@@ -2,15 +2,14 @@
 
 #linktab-wrapper{
     background-color: $secondary-color;
-    border-radius: 10px 10px 0 0;
-    box-shadow: 2px 2px rgba(0,0,0,0.5);
+    border: solid thin white;
+    border-radius: 5px;
     flex-grow: 1;
     margin-left: 1rem;
     display: flex;
     justify-content: center;
     align-items: center;
     height: clamp(25%, 35%, 100%);
-    width: clamp(5%,15%,35%);
     span{
         text-transform: uppercase;
         font-weight: 800;


### PR DESCRIPTION
I refactored the `<LinkTab>` styling away from tab design. This new
design seems cleaner and works better with the ombre background.